### PR TITLE
validation helper: generating opening/closing html tags out of the loop

### DIFF
--- a/engine/tg_helpers/validation_helper.php
+++ b/engine/tg_helpers/validation_helper.php
@@ -438,12 +438,12 @@ function validation_errors($opening_html=NULL, $closing_html=NULL) {
     if (isset($_SESSION['form_submission_errors'])) {
         $form_submission_errors = $_SESSION['form_submission_errors'];
 
+        if (!isset($opening_html)) {
+            $opening_html = '<p style="color: red;">';
+            $closing_html = '</p>';
+        }
+        
         foreach($form_submission_errors as $form_submission_error) {
-
-            if (!isset($opening_html)) {
-                $opening_html = '<p style="color: red;">';
-                $closing_html = '</p>';
-            }
 
             echo $opening_html.$form_submission_error.$closing_html;
             


### PR DESCRIPTION
Since all error messages use the same opening and closing html tags, generating them over and over again in loop is not necessary.